### PR TITLE
Removes replacement of phpseclib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,6 @@
         "mockery/mockery": "dev-master",
         "orchestra/testbench": "2.1.*"
     },
-    "replace": {
-        "phpseclib/phpseclib": "0.3.*"
-    },
     "autoload": {
         "classmap": [
             "src/migrations",


### PR DESCRIPTION
Please remove the "replace" property containing phpseclib. This project does not replace it and causes confusion for those using packagist.org to get phpseclib.
